### PR TITLE
Build scripts: IntelliJ runconfs & dependency stuff

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,10 @@ loom {
 			sourceSet(sourceSets["client"])
 		}
 	}
+
+	runConfigs.configureEach {
+		ideConfigGenerated(true)
+	}
 }
 
 val cobaltBuildTools by configurations.creating {
@@ -96,6 +100,10 @@ val instrumentForCobalt = tasks.register("InstrumentForCobalt", JavaExec::class)
 }
 tasks["compileClientJava"].finalizedBy(instrumentForCobalt)
 tasks.jar { dependsOn(instrumentForCobalt) }
+
+tasks.named("runClient") {
+	dependsOn(instrumentForCobalt)
+}
 
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task


### PR DESCRIPTION
+ Now generates IntelliJ IDEA run configurations for all projects, because 1.21 is no longer the root project because of Stonecutter
    + note: these run configurations still don't work lol
+ Makes runClient depend on instrumentForCobalt to shut up gradle being very confused about dependencies
+ No idea if this works with more than one version oops