### PR TITLE
Require that Cobalt rewriter runs as part of build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,8 +87,10 @@ val instrumentForCobalt = tasks.register("InstrumentForCobalt", JavaExec::class)
 
 	args = listOf(luaDirectory.asFile.absolutePath)
 }
-tasks["compileClientJava"].finalizedBy(instrumentForCobalt)
 tasks.jar { dependsOn(instrumentForCobalt) }
+tasks.named("clientClasses") {
+	dependsOn(instrumentForCobalt)
+}
 
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task


### PR DESCRIPTION
(instead of potentially running after the game launch task if the Gradle scheduler is having a bad day, which causes all sorts of problems)